### PR TITLE
Hotfix for follower functionality

### DIFF
--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -16,7 +16,7 @@ class ProfilesController extends Controller
      */
     public function index(User $user)
     {
-        $follows = (auth()->user()) ? auth()->user()->following->contains($user) : false;
+        $follows = (auth()->user()) ? auth()->user()->following->contains($user->id) : false;
 
         return view('profiles/index', compact('user', 'follows'));
     }

--- a/resources/views/profiles/index.blade.php
+++ b/resources/views/profiles/index.blade.php
@@ -33,7 +33,7 @@
                     @endif
                 </div>
                 <div style="padding-right: 3%;"><strong>{{ $user->profile->followers->count() }}</strong> 
-                    @if($user->posts->count()==1)
+                    @if($user->profile->followers->count()==1)
                         follower
                     @else
                         followers


### PR DESCRIPTION
Follow button did not get updated on reload because of trying to identify if user is part of the following instead of the user's id. Also fixed issue where follower/followers functionality relied on post number instead of the actual follower number